### PR TITLE
Update plugin according to breaking changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ const generic = {
     'context.library.version': 'properties.$lib_version',
     'context.ip': 'ip',
     messageId: '$insert_id',
-    originalTimestamp: 'sent_at',
+    originalTimestamp: 'timestamp',
     userId: ['$user_id', 'distinct_id'],
     anonymousId: ['properties.$anon_distinct_id', 'properties.$device_id', 'properties.distinct_id'],
     'context.active_feature_flags': 'properties.$active_feature_flags',


### PR DESCRIPTION
Hey team! We're pushing a breaking change that will no longer send `sent_at` with the event payload and will send the correct value (`timestamp`) instead. This makes sure the plugin handles this.